### PR TITLE
Fix import statements for package consistency

### DIFF
--- a/vitals/biomarkers/helpers.py
+++ b/vitals/biomarkers/helpers.py
@@ -1,7 +1,8 @@
 from typing import TypeVar
 
-import schemas
 from pydantic import BaseModel
+
+from vitals.biomarkers import schemas
 
 Biomarkers = TypeVar("Biomarkers", bound=BaseModel)
 Units = schemas.PhenoageUnits | schemas.Score2Units

--- a/vitals/biomarkers/io.py
+++ b/vitals/biomarkers/io.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import helpers
+from vitals.biomarkers import helpers
 
 
 def update(input_file: Path) -> dict:

--- a/vitals/phenoage/compute.py
+++ b/vitals/phenoage/compute.py
@@ -1,6 +1,7 @@
 import numpy as np
-from biomarkers import helpers, schemas
 from pydantic import BaseModel
+
+from vitals.biomarkers import helpers, schemas
 
 
 class LinearModel(BaseModel):

--- a/vitals/score2/compute.py
+++ b/vitals/score2/compute.py
@@ -6,8 +6,9 @@ in apparently healthy individuals aged 40-69 years in Europe.
 """
 
 import numpy as np
-from biomarkers import helpers, schemas
 from pydantic import BaseModel
+
+from vitals.biomarkers import helpers, schemas
 
 
 class ModelCoefficients(BaseModel):


### PR DESCRIPTION
## Summary
- Standardize import statements across the vitals package to use absolute imports
- Convert relative imports (e.g., `from biomarkers import helpers`) to absolute imports (e.g., `from vitals.biomarkers import helpers`)
- Ensure consistent import style following Python best practices

## Changes
- Updated imports in `vitals/biomarkers/helpers.py`
- Updated imports in `vitals/biomarkers/io.py`
- Updated imports in `vitals/phenoage/compute.py`
- Updated imports in `vitals/score2/compute.py`

## Test plan
- [x] All existing tests pass
- [x] Python files compile without errors
- [x] Import statements follow PEP8 guidelines

Fixes #3

🤖 Generated with [opencode](https://opencode.ai)